### PR TITLE
On multiple runs, open only a single file browser

### DIFF
--- a/big_sleep/big_sleep.py
+++ b/big_sleep/big_sleep.py
@@ -230,6 +230,7 @@ class Imagine(nn.Module):
 
         if self.open_folder:
             open_folder('./')
+            self.open_folder = False
 
         for epoch in trange(self.epochs, desc = 'epochs'):
             pbar = trange(self.iterations, desc='iteration')


### PR DESCRIPTION
Previously, on a 200 runs batch it opened 200 explorer windows