### PR TITLE
Possibly fix deterministic (seeded) generation

### DIFF
--- a/big_sleep/big_sleep.py
+++ b/big_sleep/big_sleep.py
@@ -10,7 +10,6 @@ import os
 import sys
 import subprocess
 import signal
-import random
 from pathlib import Path
 from tqdm import trange
 from collections import namedtuple
@@ -175,10 +174,9 @@ class Imagine(nn.Module):
         super().__init__()
 
         if exists(seed):
+            assert not bilinear, 'the deterministic (seeded) operation does not work with interpolation, yet (ask pytorch)'
+            torch.set_deterministic(True)
             torch.manual_seed(seed)
-            torch.cuda.manual_seed(seed)
-            random.seed(seed)
-            torch.backends.cudnn.deterministic=True
 
         self.epochs = epochs
         self.iterations = iterations


### PR DESCRIPTION
On a Windows machine this code is sufficient for having reproducible results pixel-to-pixel.
Also tried the effect of np.random.seed() and random.seed() but they don't seem to have any
effect, at least on my configuration (PyTorch 1.7.1, CUDA 10.1, Windows x64).

This introduces a slowdown of ~6%, but honors the seed. Interpolation is not supported with
determinism because of the 'upsample_bilinear2d_backward_cuda' operation.

The code replaced (below) also seems to have some virtues as the style is generally very
similar, but there is some variability on the appearance:
  torch.cuda.manual_seed(seed)
  torch.backends.cudnn.deterministic=True
(the lines above are now replaced by torch.set_deterministic(True))