### PR TITLE
Multiple Phrases and "minmax" Training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .vscode/
+CLIP/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,44 @@ dream = Imagine(
 dream()
 ```
 
+> You can now train more than one phrase using the delimiter "\\"
+
+### Train on Multiple Phrases
+In this example we train on three phrases:
+- `an armchair in the form of pikachu` 
+- `an armchair imitating pikachu`
+- `abstract`,
+```python
+from big_sleep import Imagine
+
+dream = Imagine(
+    text = "an armchair in the form of pikachu\\an armchair imitating pikachu\\abstract",
+    lr = 5e-2,
+    save_every = 25,
+    save_progress = True
+)
+
+dream()
+```
+
+### Penalize certain prompts as well!
+In this example we train on the three phrases from before,
+**and** *penalize* the phrases `blur` and `zoom`. 
+- `abstract`,
+```python
+from big_sleep import Imagine
+
+dream = Imagine(
+    text = "an armchair in the form of pikachu\\an armchair imitating pikachu\\abstract",
+    text_min = "blur\\zoom",
+    lr = 5e-2,
+    save_every = 25,
+    save_progress = True
+)
+
+dream()
+```
+
 You can also set a new text by using the `.set_text(<str>)` command
 
 ```python

--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ dream()
 
 ### Train on Multiple Phrases
 In this example we train on three phrases:
+
 - `an armchair in the form of pikachu` 
 - `an armchair imitating pikachu`
-- `abstract`,
+- `abstract`
+
 ```python
 from big_sleep import Imagine
 
@@ -108,22 +110,22 @@ dream()
 ```
 
 ### Penalize certain prompts as well!
+
 In this example we train on the three phrases from before,
-**and** *penalize* the phrases `blur` and `zoom`. 
-- `abstract`,
+
+**and** *penalize* the phrases:
+- `blur`
+- `zoom`
 ```python
 from big_sleep import Imagine
 
 dream = Imagine(
     text = "an armchair in the form of pikachu\\an armchair imitating pikachu\\abstract",
     text_min = "blur\\zoom",
-    lr = 5e-2,
-    save_every = 25,
-    save_progress = True
 )
-
 dream()
 ```
+
 
 You can also set a new text by using the `.set_text(<str>)` command
 

--- a/big_sleep/big_sleep.py
+++ b/big_sleep/big_sleep.py
@@ -330,7 +330,10 @@ class Imagine(nn.Module):
     def set_text(self, text, text_min=""):
         self.text = text
         self.text_min = text_min
-        textpath = underscorify(text[:128])
+        textpath = text[:255]
+        if len(text_min) > 0:
+            textpath = textpath + "_wout_" + text_min[:255]
+        textpath = underscorify(textpath)
         if self.save_date_time:
             textpath = datetime.now().strftime("%y%m%d-%H%M%S-") + textpath
 

--- a/big_sleep/cli.py
+++ b/big_sleep/cli.py
@@ -6,6 +6,7 @@ from .version import __version__;
 
 def train(
     text,
+    text_min="",
     lr = .07,
     image_size = 512,
     gradient_accumulate_every = 1,

--- a/big_sleep/cli.py
+++ b/big_sleep/cli.py
@@ -34,6 +34,7 @@ def train(
 
     imagine = Imagine(
         text,
+        text_min=text_min,
         lr = lr,
         image_size = image_size,
         gradient_accumulate_every = gradient_accumulate_every,

--- a/test/multi_prompt_minmax.py
+++ b/test/multi_prompt_minmax.py
@@ -1,0 +1,43 @@
+import time
+import shutil
+import torch
+from big_sleep import Imagine
+
+terminate = False
+
+def signal_handling(signum,frame):
+    global terminate
+    terminate = True
+
+num_attempts = 4
+for attempt in range(num_attempts):
+    dream = Imagine(
+        text = "an armchair in the form of pikachu\\an armchair imitating pikachu\\abstract",
+        text_min = "blur\\zoom",
+        lr = 7e-2,
+        image_size = 512,
+        gradient_accumulate_every = 1,
+        save_every = 50,
+        epochs = 5,
+        iterations = 50,
+        save_progress = False,
+        bilinear = False,
+        open_folder = False,
+        seed = None,
+        torch_deterministic = False,
+        max_classes = 20,
+        class_temperature = 2.,
+        save_date_time = False,
+        save_best = True,
+        experimental_resample = True,
+        ema_decay = 0.99
+    )
+    dream()
+    shutil.copy(dream.textpath + ".best.png", f"{attempt}.png")
+    try:
+        time.sleep(2)
+        del dream
+        time.sleep(2)
+        torch.cuda.empty_cache()
+    except Exception:
+        torch.cuda.empty_cache()


### PR DESCRIPTION
I added the ability to train on multiple prompts. Simply pass a `\` delimiter (`"\\"` in python strings) to separate each phrase.

You can also send in phrases to penalize in the output. This can be surprisingly effective (or a total failure). 

### Train on Multiple Phrases
In this example we train on three phrases:

- `an armchair in the form of pikachu` 
- `an armchair imitating pikachu`
- `abstract`

```python
from big_sleep import Imagine

dream = Imagine(
    text = "an armchair in the form of pikachu\\an armchair imitating pikachu\\abstract",
    lr = 5e-2,
    save_every = 25,
    save_progress = True
)

dream()
```

### Penalize certain prompts as well!

In this example we train on the three phrases from before,

**and** *penalize* the phrases:
- `blur`
- `zoom`
```python
from big_sleep import Imagine

dream = Imagine(
    text = "an armchair in the form of pikachu\\an armchair imitating pikachu\\abstract",
    text_min = "blur\\zoom",
)
dream()
```
### Basic experiment showing it works to a degree

This image is generated from the cell above. 

![pika_2](https://user-images.githubusercontent.com/3994972/109432745-528d0a00-79d2-11eb-967d-03f0bfcaa775.png)

What happens if we minimize the word "yellow"?

![armchair_pika_0](https://user-images.githubusercontent.com/3994972/109433102-38ecc200-79d4-11eb-98c7-fc1050def0ce.png)


