### PR TITLE
Error throws "Deep Daze" instead of "Big Sleep" fix

### DIFF
--- a/big_sleep/big_sleep.py
+++ b/big_sleep/big_sleep.py
@@ -127,7 +127,7 @@ class Model(nn.Module):
     ):
         super().__init__()
         assert image_size in (128, 256, 512), 'image size must be one of 128, 256, or 512'
-
+        self.biggan = BigGAN.from_pretrained(f'biggan-deep-{image_size}')
         self.max_classes = max_classes
         self.class_temperature = class_temperature
         self.ema_decay\

--- a/big_sleep/big_sleep.py
+++ b/big_sleep/big_sleep.py
@@ -21,7 +21,7 @@ from big_sleep.resample import resample
 from big_sleep.biggan import BigGAN
 from big_sleep.clip import load, tokenize
 
-assert torch.cuda.is_available(), 'CUDA must be available in order to use Deep Daze'
+assert torch.cuda.is_available(), 'CUDA must be available in order to use Big Sleep'
 
 # graceful keyboard interrupt
 
@@ -127,7 +127,6 @@ class Model(nn.Module):
     ):
         super().__init__()
         assert image_size in (128, 256, 512), 'image size must be one of 128, 256, or 512'
-        self.biggan = BigGAN.from_pretrained(f'biggan-deep-{image_size}')
 
         self.max_classes = max_classes
         self.class_temperature = class_temperature


### PR DESCRIPTION
simple typo fix when not using GPU when running the model