### PR TITLE
Save restore latent

### DIFF
--- a/big_sleep/cli.py
+++ b/big_sleep/cli.py
@@ -31,6 +31,8 @@ def train(
     ema_decay = 0.5,
     num_cutouts = 128,
     center_bias = False,
+    save_latents = False,
+    restore_latents_filename = None,
 ):
     print(f'Starting up... v{__version__}')
 
@@ -61,6 +63,8 @@ def train(
         ema_decay = ema_decay,
         num_cutouts = num_cutouts,
         center_bias = center_bias,
+        save_latents = save_latents,
+        restore_latents_filename = restore_latents_filename,
     )
 
     if not overwrite and imagine.filename.exists():


### PR DESCRIPTION
A slight update to the latents functionality added by @LoudMurmur. This adds the arguments to the CLI, supports saving latents without also needing save_progress=True, and supports resetting the optimizer when resuming from a previous backup file. This allows you to develop an image, switch the text prompt, then continue from the starting point achieved by the first run. If the optimizer isn't reset, it will be just like resuming using the old text prompt.